### PR TITLE
Fix/macros comments

### DIFF
--- a/src/main/java/fr/unice/polytech/si3/miaou/brainfuck/InstructionParser.java
+++ b/src/main/java/fr/unice/polytech/si3/miaou/brainfuck/InstructionParser.java
@@ -50,15 +50,13 @@ public class InstructionParser {
 	public InstructionParser(Stream<String> stream) {
 		this();
 
-		stream = (new MacroParser(stream)).parse();
-
-		// Does it need a .filter(l -> !"".equals) ?
-		stream.filter(l -> !l.startsWith("#"))
+		stream.filter(l -> !l.startsWith("#")) // Remove lines starting with a comment
 		.map(l -> {
 			int p = l.indexOf("#");
-			if (p > 0) l = l.substring(0, p);
-			return l.trim();
+			if (p > 0) l = l.substring(0, p); // Remove comments from the line
+			return l.trim(); // Remove leading and trailing whitespaces from the line
 		})
+		.flatMap(new MacroParser()) // Expand macros
 		.forEachOrdered(line -> {
 			Instruction instr = iset.getOp(line); // Tries to parse the whole line (ie. long format)
 

--- a/src/main/java/fr/unice/polytech/si3/miaou/brainfuck/InstructionParser.java
+++ b/src/main/java/fr/unice/polytech/si3/miaou/brainfuck/InstructionParser.java
@@ -52,19 +52,14 @@ public class InstructionParser {
 
 		stream = (new MacroParser(stream)).parse();
 
-		stream.forEachOrdered(line -> {
-			if (line.startsWith("#")) return;
-
-			int posCom = line.indexOf("#");
-
-			if (posCom != -1) {
-				line = line.substring(0, posCom);
-			}
-
-			line = line.trim();
-
-			if (line.isEmpty()) return;
-
+		// Does it need a .filter(l -> !"".equals) ?
+		stream.filter(l -> !l.startsWith("#"))
+		.map(l -> {
+			int p = l.indexOf("#");
+			if (p > 0) l = l.substring(0, p);
+			return l.trim();
+		})
+		.forEachOrdered(line -> {
 			Instruction instr = iset.getOp(line); // Tries to parse the whole line (ie. long format)
 
 			if (instr != null) {
@@ -76,7 +71,8 @@ public class InstructionParser {
 					if (c == ' ' || c == '\t') continue;
 
 					instr = iset.getOp(c);
-					if (instr == null) 	throw new InvalidInstructionException(c);
+
+					if (instr == null) throw new InvalidInstructionException(c);
 					instructions.add(instr);
 					jumptable.bind(instr, instructions.size());
 				}

--- a/src/main/java/fr/unice/polytech/si3/miaou/brainfuck/JumpTable.java
+++ b/src/main/java/fr/unice/polytech/si3/miaou/brainfuck/JumpTable.java
@@ -16,7 +16,7 @@ import fr.unice.polytech.si3.miaou.brainfuck.exceptions.InvalidInstructionExcept
 /**
  * instructions from a List and execute them.
  *
- * @author Nassim Bounouas 
+ * @author Nassim Bounouas
  * @see Instruction
  */
 public class JumpTable {
@@ -25,7 +25,7 @@ public class JumpTable {
 	 * Hashmap containing conditionnal jump instructions indexes
 	 */
 	private Map<Integer, Integer> conditionnalJumpMap;
-	
+
 	/**
 	 * Stack used as a buffer to store a Jump waiting its Back instruction
 	 */
@@ -40,7 +40,7 @@ public class JumpTable {
 	}
 
 	/**
-	 * Add and associate a Jump/Back instruction to its corresponding instruction 
+	 * Add and associate a Jump/Back instruction to its corresponding instruction
 	 *
 	 * @param i The instruction to add in the Jumptable
 	 * @param index The instruction index
@@ -73,9 +73,9 @@ public class JumpTable {
 	@Override
 	public String toString() {
 		String str = "";
-		Iterator it = this.conditionnalJumpMap.entrySet().iterator();
+		Iterator<Map.Entry<Integer, Integer>> it = this.conditionnalJumpMap.entrySet().iterator();
 		while (it.hasNext()) {
-			Map.Entry pair = (Map.Entry)it.next();
+			Map.Entry<Integer, Integer> pair = it.next();
 			str += pair.getKey() + " = " + pair.getValue() + "\n";
 		}
 		str += "Size : " + this.conditionnalJumpMap.size() + "\n";

--- a/src/main/java/fr/unice/polytech/si3/miaou/brainfuck/Main.java
+++ b/src/main/java/fr/unice/polytech/si3/miaou/brainfuck/Main.java
@@ -7,8 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.Files;
 
-import java.util.ArrayList;
-
 import fr.unice.polytech.si3.miaou.brainfuck.virtualmachine.Machine;
 import fr.unice.polytech.si3.miaou.brainfuck.io.Io;
 import fr.unice.polytech.si3.miaou.brainfuck.exceptions.BrainfuckException;
@@ -28,8 +26,6 @@ public class Main {
 	 */
 	private ArgParser argp;
 
-	List list = new ArrayList();
-
 	/**
 	 * Constructs a Main with the given ArgParser, ie. arguments parsed from command line parameters.
 	 *
@@ -37,8 +33,6 @@ public class Main {
 	 */
 	Main(ArgParser argp) {
 		this.argp = argp;
-
-		list.add(2);
 	}
 
 	/**


### PR DESCRIPTION
Depends on #56 because of formatting changes only.

Comments and whitespaces must be removed before both expanding the macros and parsing the instructions.

Thus, my previously rejected improvements are relevant in this case because we need to alter the Stream itself (in fact a new one is generated while consuming the old one's lines, for those who don't know how functional processing of Streams work). Not that efficient but the code is pretty and simple.

Also MacroParser now implements the Function functional interface for the object to be passed directly to the Stream's flatMap() function. (which will call the apply() method for each line)